### PR TITLE
fix: clear pad title when pad is removed (#109)

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -11,7 +11,9 @@
         "handleMessage": "ep_set_title_on_pad/handleMessage",
         "eejsBlock_mySettings": "ep_set_title_on_pad/index",
         "exportFileName":"ep_set_title_on_pad/index",
-        "clientVars": "ep_set_title_on_pad/handleMessage"
+        "clientVars": "ep_set_title_on_pad/handleMessage",
+        "padRemove": "ep_set_title_on_pad/index",
+        "padCopy": "ep_set_title_on_pad/index"
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -20,3 +20,12 @@ exports.eejsBlock_mySettings = (hookName, args, cb) => {
   args.content += eejs.require('ep_set_title_on_pad/templates/settings.ejs');
   cb();
 };
+
+exports.padRemove = async (hookName, {pad}) => {
+  await db.remove(`title:${pad.id}`);
+};
+
+exports.padCopy = async (hookName, {srcPad, dstPad}) => {
+  const title = await db.get(`title:${srcPad.id}`);
+  if (title) await db.set(`title:${dstPad.id}`, title);
+};

--- a/static/tests/backend/specs/title_lifecycle.js
+++ b/static/tests/backend/specs/title_lifecycle.js
@@ -20,7 +20,8 @@ describe(__filename, function () {
 
     await pad.remove();
 
-    assert.equal(await DB.get(titleKey(padId)), null);
+    // Different DB drivers return either null or undefined for missing keys.
+    assert(await DB.get(titleKey(padId)) == null);
   });
 
   it('copies the title when the pad is copied', async function () {

--- a/static/tests/backend/specs/title_lifecycle.js
+++ b/static/tests/backend/specs/title_lifecycle.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assert = require('assert').strict;
+const common = require('ep_etherpad-lite/tests/backend/common');
+const padManager = require('ep_etherpad-lite/node/db/PadManager');
+const DB = require('ep_etherpad-lite/node/db/DB');
+
+const titleKey = (padId) => `title:${padId}`;
+
+describe(__filename, function () {
+  before(async function () {
+    await common.init();
+  });
+
+  it('removes the title when the pad is removed (regression for #109)', async function () {
+    const padId = `title-rm-${common.randomString()}`;
+    const pad = await padManager.getPad(padId, '\n');
+    await DB.set(titleKey(padId), 'My Pad Title');
+    assert.equal(await DB.get(titleKey(padId)), 'My Pad Title');
+
+    await pad.remove();
+
+    assert.equal(await DB.get(titleKey(padId)), null);
+  });
+
+  it('copies the title when the pad is copied', async function () {
+    const srcId = `title-cp-src-${common.randomString()}`;
+    const dstId = `title-cp-dst-${common.randomString()}`;
+    const src = await padManager.getPad(srcId, '\n');
+    await DB.set(titleKey(srcId), 'Original Title');
+
+    await src.copy(dstId);
+
+    assert.equal(await DB.get(titleKey(dstId)), 'Original Title');
+
+    // cleanup
+    const dst = await padManager.getPad(dstId);
+    await src.remove();
+    await dst.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `padRemove` hook to delete the orphaned `title:<padId>` DB key when a pad is deleted
- Add `padCopy` hook so copying a pad also copies its title
- Add backend regression test (`static/tests/backend/specs/title_lifecycle.js`)

## Context
Per #109: when a pad was deleted via the API and recreated under the same id, the stale title was still present. The plugin never implemented the `padRemove` hook even though etherpad-lite has fired it [since this commit](https://github.com/ether/etherpad-lite/blob/454fec7a9f0d92c0cb22d45955d14bbc70cd85ff/src/node/db/Pad.ts#L604).

## Test plan
- [x] Backend test verifies title is removed on `pad.remove()` and copied on `pad.copy()` — passes locally (2/2)
- [ ] Confirm CI passes

Fixes #109

Generated with [Claude Code](https://claude.com/claude-code)