### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_set_title_on_pad
+# Derive Pad Title from its First Line for Etherpad
 
 [![Demo](demo.gif)](https://github.com/ether/ep_set_title_on_pad/actions/workflows/test-and-release.yml) 
 [![Backend Tests Status](https://github.com/ether/ep_set_title_on_pad/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_set_title_on_pad/actions/workflows/test-and-release.yml)


### PR DESCRIPTION
Replace the placeholder `ep_set_title_on_pad` heading in README.md with "Derive Pad Title from its First Line for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.