### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/eejs.js
+++ b/eejs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 
 exports.eejsBlock_body = (hookName, args, cb) => {
   const templateFile = 'ep_set_title_on_pad/templates/title.ejs';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_set_title_on_pad",
   "description": "Set the title on a pad in Etherpad, also includes real time updates to the UI",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "license": "Apache-2.0",
   "author": "johnyma22 (John McLear) <john@mclear.co.uk>",
   "keywords": [


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.